### PR TITLE
Release 1.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.2-dev
+version=1.2
 nexusUsername=
 nexusPassword=
 

--- a/src/main/resources/rules-config.conf
+++ b/src/main/resources/rules-config.conf
@@ -6,6 +6,6 @@ StringPropertyLengthBoundsRule {
 }
 ## hacky way to fix the class loader issue. more info https://github.com/zalando/zally/issues/1291
 UseOpenApiRule {
-  schema_urls.swagger: "http://swagger.io/v2/schema.json"
+  schema_urls.swagger: "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v2.0/schema.json"
   schema_urls.openapi3: "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json"
 }


### PR DESCRIPTION
Swagger URL pointed to "http://swagger.io/v2/schema.json" is being redirected to "http://23.22.16.221/v2/schema.json". Its causing this issue (https://github.com/thiyagu06/zally-gradle-plugin/issues/93).

To fix it, i've redirected the Swagger URL to use the V2 json URL from its GitHub repository